### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Ethereum blockchain.
 
+<a href="https://glama.ai/mcp/servers/qpjvkozof7">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/qpjvkozof7/badge" alt="Ethereum RPC Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides tools to query Ethereum blockchain data through standard JSON-RPC methods. It enables AI assistants and applications to interact with the Ethereum blockchain through a standardized protocol.


### PR DESCRIPTION
This PR adds a badge for the [Ethereum RPC MCP Server](https://glama.ai/mcp/servers/qpjvkozof7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qpjvkozof7">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/qpjvkozof7/badge" alt="Ethereum RPC Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.